### PR TITLE
Add matching pitch underwater with match angle

### DIFF
--- a/InputDirection/InputDirection_dev.lua
+++ b/InputDirection/InputDirection_dev.lua
@@ -32,8 +32,8 @@ Memory.UpdatePrevPos()
 function main()
 	Program.initFrame()
 	Program.main()
-	Joypad.send()
 	Swimming.swim("A")
+	Joypad.send()
 end
 
 function drawing()

--- a/InputDirection/InputDirection_dev/Engine.lua
+++ b/InputDirection/InputDirection_dev/Engine.lua
@@ -77,6 +77,81 @@ end
 
 function Engine.inputsForAngle()
 	goal = Settings.goalAngle
+	-- sets goal pitch for swimming
+	if Memory.Mario.Action % 0x200 >= 0x0C0 and Memory.Mario.Action % 0x200 <= 0x0EF and Settings.Layout.Button.selectedItem == Settings.Layout.Button.MATCH_ANGLE then
+		local targetPitch = goal
+		local sign = 1
+		-- shortcut for negative pitch
+		if targetPitch > 80000 then
+			targetPitch = -(targetPitch - 80000)
+		end
+		if targetPitch > 32767 then
+			targetPitch = targetPitch - 65536
+		end
+		if targetPitch < 0 then
+			targetPitch = -targetPitch
+			sign = -sign
+		end
+		if targetPitch > 16128 then
+			-- invalid target pitch
+			return {
+				angle = 0,
+				X = 0,
+				Y = 0
+			}
+		end
+		local baseStickY = targetPitch / 252
+		if baseStickY == math.floor(baseStickY) then
+			if baseStickY ~= 0 then
+				baseStickY = baseStickY + 6
+			end
+			return {
+				angle = targetPitch % 65536,
+				X = 0,
+				Y = math.floor(baseStickY) * -sign
+			}
+		end
+
+		local bestX = 0
+		local bestY = 0
+		local closestDiff = 65536
+		for newY = math.floor(baseStickY), 120 do
+			if newY ~= 1 then
+				local newX = newY * math.sqrt((16128 / targetPitch)^2 - 1)
+				if newX > 121 then break end
+				local higherPitch = math.floor(252 * newY * math.min(64 / math.sqrt(math.floor(newX)^2 + newY^2), 1))
+				local lowerPitch = math.floor(252 * newY * math.min(64 / math.sqrt(math.ceil(newX)^2 + newY^2), 1))
+				local diff = math.abs(higherPitch - targetPitch)
+				if diff < closestDiff and math.floor(newX) ~= 1 then
+					bestX = math.floor(newX)
+					bestY = newY
+					if diff == 0 then break end
+					closestDiff = diff
+				end
+				diff = math.abs(lowerPitch - targetPitch)
+				if diff < closestDiff and math.ceil(newX) ~= 1 then
+					bestX = math.ceil(newX)
+					bestY = newY
+					if diff == 0 then break end
+					closestDiff = diff
+				end
+			end
+		end
+		
+		if bestX ~= 0 then
+			bestX = bestX + 6
+		end
+		if bestY ~= 0 then
+			bestY = bestY + 6
+		end
+		
+		return {
+			angle = targetPitch % 65536,
+			X = bestX * (Memory.Mario.GlobalTimer % 2 * 2 - 1),
+			Y = bestY * -sign
+		}	
+	end
+	
 	cFacingYaw = Memory.Mario.FacingYaw
 	if(Memory.Camera.Flags % 4 < 2 and Memory.Mario.PressedButtons % 16 > 7 and Memory.Mario.HeldButtons < 128 and joypad.get(1).A == true and (Memory.Mario.Animation == 127 or Memory.Mario.Animation == 128)) then
 		cFacingYaw = Memory.Mario.GfxAngle

--- a/InputDirection/InputDirection_dev/Engine.lua
+++ b/InputDirection/InputDirection_dev/Engine.lua
@@ -82,7 +82,7 @@ function Engine.inputsForAngle()
 		local targetPitch = goal
 		local sign = 1
 		-- shortcut for negative pitch
-		if targetPitch > 80000 then
+		if targetPitch >= 80000 then
 			targetPitch = -(targetPitch - 80000)
 		end
 		if targetPitch > 32767 then

--- a/InputDirection/InputDirection_dev/Engine.lua
+++ b/InputDirection/InputDirection_dev/Engine.lua
@@ -101,7 +101,7 @@ function Engine.inputsForAngle()
 			}
 		end
 		local baseStickY = targetPitch / 252
-		if baseStickY == math.floor(baseStickY) then
+		if baseStickY == math.floor(baseStickY) and Settings.Layout.Button.strain_button.always == false then
 			if baseStickY ~= 0 then
 				baseStickY = baseStickY + 6
 			end

--- a/InputDirection/InputDirection_dev/Engine.lua
+++ b/InputDirection/InputDirection_dev/Engine.lua
@@ -80,7 +80,7 @@ function Engine.inputsForAngle()
 	-- sets goal pitch for swimming
 	if Memory.Mario.Action % 0x200 >= 0x0C0 and Memory.Mario.Action % 0x200 <= 0x0EF and Settings.Layout.Button.selectedItem == Settings.Layout.Button.MATCH_ANGLE then
 		local targetPitch = goal
-		local sign = 1
+		local signY = -1
 		-- shortcut for negative pitch
 		if targetPitch >= 80000 then
 			targetPitch = -(targetPitch - 80000)
@@ -90,7 +90,7 @@ function Engine.inputsForAngle()
 		end
 		if targetPitch < 0 then
 			targetPitch = -targetPitch
-			sign = -sign
+			signY = -signY
 		end
 		if targetPitch > 16128 then
 			-- invalid target pitch
@@ -108,7 +108,7 @@ function Engine.inputsForAngle()
 			return {
 				angle = targetPitch % 65536,
 				X = 0,
-				Y = math.floor(baseStickY) * -sign
+				Y = math.floor(baseStickY) * signY
 			}
 		end
 
@@ -145,11 +145,21 @@ function Engine.inputsForAngle()
 			bestY = bestY + 6
 		end
 		
+		local signX
+		if Settings.Layout.Button.strain_button.always == true then
+			signX = -1
+		else
+			signX = Memory.Mario.GlobalTimer % 2 * 2 - 1
+		end
+		if Settings.Layout.Button.strain_button.right == true then
+			signX = -signX
+		end
+
 		return {
 			angle = targetPitch % 65536,
-			X = bestX * (Memory.Mario.GlobalTimer % 2 * 2 - 1),
-			Y = bestY * -sign
-		}	
+			X = bestX * signX,
+			Y = bestY * signY
+		}
 	end
 	
 	cFacingYaw = Memory.Mario.FacingYaw

--- a/InputDirection/InputDirection_dev/Swimming.lua
+++ b/InputDirection/InputDirection_dev/Swimming.lua
@@ -11,12 +11,10 @@ function Swimming.swim(button)
 	if Memory.Mario.Action == SWIMMING_ANIMATION_2
 		or Memory.Mario.Action == WATER_ACTION_END
 		or Memory.Mario.Action == WATER_IDLE then
-		j = joypad.get(1)
 		if button == "B" or button == "b" then
-			j.B = 1
+			Joypad.set('B', 1)
 		elseif button == "A" or button == "a" then
-			j.A = 1
+			Joypad.set('A', 1)
 		end
-		joypad.set(1, j)
 	end
 end

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The all-in-one lua script that lets you precisely control your inputs - regardle
   - same as `Match Yaw` but for the opposite direction
 - Match Angle
   - holds the joystick in the direction of the specified angle
-    - if used underwater, holds the joystick in the direction of the specified pitch (can add 80000 to the angle for negative pitch)
+  - if used underwater, holds the joystick in the direction of the specified pitch
+    - can add 80000 to the angle for negative pitch
+    - use Left/Right to toggle parity and Always to toggle stick position alternation
 - .99
   - hold a joystick angle that makes Mario's speed go to 31.99 or 47.99 speed for 1 frame (when possible)
 - Always

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The all-in-one lua script that lets you precisely control your inputs - regardle
   - same as `Match Yaw` but for the opposite direction
 - Match Angle
   - holds the joystick in the direction of the specified angle
+    - if used underwater, holds the joystick in the direction of the specified pitch (can add 80000 to the angle for negative pitch)
 - .99
   - hold a joystick angle that makes Mario's speed go to 31.99 or 47.99 speed for 1 frame (when possible)
 - Always


### PR DESCRIPTION
new feature intended to make tasing swimming easier
- use match angle while swimming to swim at a specified pitch
- allows for swimming straight with a non-252 multiple of pitch without manually wiggling the joystick
- can set negative pitch by either adding 80000 or subtracting from 65536
- doesn't affect match angle outside of swimming, since the feature only triggers in actions related to swimming
some other parts of the code were slightly modified to make this work